### PR TITLE
Fix Windows-only pthread-win32 leaking into Linux builds

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,13 +4,17 @@ module(
     compatibility_level = 1,
 )
 
-new_local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
+bazel_dep(name = "rules_cc", version = "0.2.16")
+bazel_dep(name = "platforms", version = "1.0.0")
+
+new_local_repository = use_repo_rule(
+    "@bazel_tools//tools/build_defs/repo:local.bzl",
+    "new_local_repository",
+)
 
 new_local_repository(
-	name = "win32_libs",
-	# NOTE: replace with your own Windows libraries path
-	path = "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.26100.0/um/x64",
-	build_file_content = """
+    name = "win32_libs",
+    build_file_content = """
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -41,14 +45,15 @@ cc_library(
 	],
 )
 """,
+    # NOTE: replace with your own Windows libraries path
+    path = "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.26100.0/um/x64",
 )
 
 # linux
 
 new_local_repository(
-	name = "linux_libs",
-	path = "/usr/lib/x86_64-linux-gnu",
-	build_file_content = """
+    name = "linux_libs",
+    build_file_content = """
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -62,4 +67,5 @@ cc_library(
 	srcs = ["libpthread.so"],
 )
 """,
+    path = "/usr/lib/x86_64-linux-gnu",
 )

--- a/jukebox/Decoders/fluidsynth/BUILD
+++ b/jukebox/Decoders/fluidsynth/BUILD
@@ -1,26 +1,31 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//jukebox:__subpackages__"])
 
 cc_library(
-	name = "fluidsynth",
-	srcs = [
-		"fs.c",
-	],
-	hdrs = [
-		"fs.h",
-		"soundfont.h",
-	],
-	defines = select({
-		"@bazel_tools//src/conditions:windows": [
-			"HAVE_WINDOWS_H",
-			"WIN32",
-		],
-		"//conditions:default": ["HAVE_UNISTD_H"],
-	}),
-	deps = select({
-		"@bazel_tools//src/conditions:windows": [
-			"//jukebox/Decoders/fluidsynth/pthread-win32",
-		],
-		"//conditions:default": [],
-	}),
-	includes = ["./pthread-win32"],
+    name = "fluidsynth",
+    srcs = [
+        "fs.c",
+    ],
+    hdrs = [
+        "fs.h",
+        "soundfont.h",
+    ],
+    defines = select({
+        "@bazel_tools//src/conditions:windows": [
+            "HAVE_WINDOWS_H",
+            "WIN32",
+        ],
+        "//conditions:default": ["HAVE_UNISTD_H"],
+    }),
+    includes = select({
+        "@bazel_tools//src/conditions:windows": ["./pthread-win32"],
+        "//conditions:default": [],
+    }),
+    deps = select({
+        "@bazel_tools//src/conditions:windows": [
+            "//jukebox/Decoders/fluidsynth/pthread-win32",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/jukebox/Decoders/fluidsynth/pthread-win32/BUILD
+++ b/jukebox/Decoders/fluidsynth/pthread-win32/BUILD
@@ -1,16 +1,16 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//jukebox:__subpackages__"])
 
 cc_library(
-	name = "pthread-win32",
-	srcs = ["pthread.c"],
-	hdrs = ["pthread.h"],
-	textual_hdrs = glob([
-		"*.c",
-		"*.h",
-    ]),
-	defines = [
-		"HAVE_STRUCT_TIMESPEC",
-		"PTW32_STATIC_LIB",
-		"PTW32_BUILD_INLINED",
-	],
+    name = "pthread-win32",
+    srcs = ["pthread.c"],
+    hdrs = glob(["*.h"]),
+    defines = [
+        "HAVE_STRUCT_TIMESPEC",
+        "PTW32_STATIC_LIB",
+        "PTW32_BUILD_INLINED",
+    ],
+    target_compatible_with = ["@platforms//os:windows"],
+    textual_hdrs = glob(["*.c"]),
 )


### PR DESCRIPTION
The fluidsynth BUILD file was always adding./pthread-win32 to the
include path, even on non-Windows platforms. That caused
Linux/clang-tidy (and compile_commands generation)
to pick up Windows pthread headers, leading to errors like \_\_declspec
not supported and timespec redefinition.

This change:

- Makes the pthread-win32 include path and dependency Windows-only using
  select().
- Marks the pthread-win32 cc_library as Windows-only
  (target_compatible_with = ["@platforms//os:windows"]) so it can’t be
  pulled into Linux builds by mistake.
- Adds explicit rules_cc and platforms deps required for cc_library and
  the Windows constraint.
- Cleans up the pthread-win32 rule’s headers to avoid treating .c files
  as headers and fixes file formatting/newline.
